### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions: {}
 
     steps:
       - name: Trigger apt-repo rebuild


### PR DESCRIPTION
Potential fix for [https://github.com/b0bbywan/go-mpd-discplayer/security/code-scanning/1](https://github.com/b0bbywan/go-mpd-discplayer/security/code-scanning/1)

Add an explicit `permissions` block to the `notify-apt-repo` job in `.github/workflows/build.yml`.  
Best fix without changing functionality: set `permissions: {}` for that job, since it uses `secrets.APT_REPO_TOKEN` and does not appear to require `GITHUB_TOKEN` access. This enforces no `GITHUB_TOKEN` scopes and satisfies CodeQL’s recommendation for explicit restriction.

Change region:
- File: `.github/workflows/build.yml`
- Under job `notify-apt-repo` (after `if:` and before `steps:`), add:
  - `permissions: {}`

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
